### PR TITLE
feat : US 4 드라이버 등록 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
     implementation 'com.h2database:h2:1.4.200'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/mate/carpool/domain/driver/aggregate/Car.java
+++ b/src/main/java/com/mate/carpool/domain/driver/aggregate/Car.java
@@ -1,5 +1,6 @@
 package com.mate.carpool.domain.driver.aggregate;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import javax.persistence.Column;
@@ -13,4 +14,13 @@ public class Car {
 
     @Column(name = "car_image_url")
     private String imageUrl;
+
+    protected Car() {
+    }
+
+    @Builder
+    public Car(String number, String imageUrl) {
+        this.number = number;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/mate/carpool/domain/driver/aggregate/Driver.java
+++ b/src/main/java/com/mate/carpool/domain/driver/aggregate/Driver.java
@@ -1,6 +1,9 @@
 package com.mate.carpool.domain.driver.aggregate;
 
+import com.mate.carpool.domain.driver.dto.DriverCreateDTO;
+import com.mate.carpool.domain.member.aggregate.Member;
 import com.mate.carpool.domain.member.aggregate.MemberId;
+import lombok.Builder;
 import lombok.Getter;
 
 import javax.persistence.*;
@@ -20,4 +23,16 @@ public class Driver {
 
     @Embedded
     private MemberId memberId;
+
+
+    protected Driver() {
+    }
+
+    @Builder
+    public Driver(String carNumber, String carImageUrl, String phoneNumber, MemberId memberId) {
+        this.id = new DriverId();
+        this.car = new Car(carNumber, carImageUrl);
+        this.phoneNumber = phoneNumber;
+        this.memberId = memberId;
+    }
 }

--- a/src/main/java/com/mate/carpool/domain/driver/dto/DriverCreateDTO.java
+++ b/src/main/java/com/mate/carpool/domain/driver/dto/DriverCreateDTO.java
@@ -1,0 +1,28 @@
+package com.mate.carpool.domain.driver.dto;
+
+import com.mate.carpool.domain.driver.aggregate.Driver;
+import com.mate.carpool.domain.member.aggregate.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DriverCreateDTO {
+    private String carNumber;
+    private String phoneNumber;
+
+
+    @Builder
+    public DriverCreateDTO(String carNumber, String phoneNumber) {
+        this.carNumber = carNumber;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public Driver toEntity(Member member, String carImageUrl) {
+        return Driver.builder()
+                .carNumber(carNumber)
+                .carImageUrl(carImageUrl)
+                .phoneNumber(phoneNumber)
+                .memberId(member.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/mate/carpool/domain/driver/repository/DriverRepository.java
+++ b/src/main/java/com/mate/carpool/domain/driver/repository/DriverRepository.java
@@ -1,0 +1,12 @@
+package com.mate.carpool.domain.driver.repository;
+
+import com.mate.carpool.domain.driver.aggregate.Driver;
+import com.mate.carpool.domain.driver.aggregate.DriverId;
+import com.mate.carpool.domain.member.aggregate.MemberId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DriverRepository extends JpaRepository<Driver, DriverId> {
+    boolean existsByMemberId(MemberId memberId);
+}

--- a/src/main/java/com/mate/carpool/domain/driver/service/CarpoolDriverService.java
+++ b/src/main/java/com/mate/carpool/domain/driver/service/CarpoolDriverService.java
@@ -1,0 +1,44 @@
+package com.mate.carpool.domain.driver.service;
+
+import com.mate.carpool.domain.driver.aggregate.Driver;
+import com.mate.carpool.domain.driver.dto.DriverCreateDTO;
+import com.mate.carpool.domain.driver.repository.DriverRepository;
+import com.mate.carpool.domain.image.service.ImageService;
+import com.mate.carpool.domain.member.aggregate.Member;
+import com.mate.carpool.domain.member.aggregate.MemberType;
+import com.mate.carpool.domain.member.repository.MemberRepository;
+import com.mate.carpool.shared.exception.CustomHttpException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class CarpoolDriverService {
+    private final DriverRepository driverRepository;
+    private final MemberRepository memberRepository;
+    private final ImageService imageService;
+
+    @Transactional
+    public void create(String email, MultipartFile image, DriverCreateDTO dto) throws IOException {
+        // 우리 회원인지 조회
+        Member member = memberRepository.findByCredentialEmail(email)
+                .orElseThrow(() -> new CustomHttpException(HttpStatus.BAD_REQUEST, "사용자 정보를 찾을 수 없습니다."));
+
+        // 기존에 이미 회원 정보가 있는지 확인이 필요
+        if (driverRepository.existsByMemberId(member.getId())) {
+            throw new CustomHttpException(HttpStatus.CONFLICT, "이미 드라이버 정보가 있습니다.");
+        }
+
+        String imageUrl = imageService.upload(image);
+
+        Driver driver = dto.toEntity(member, imageUrl);
+        driver.getId().generate(); // id 생성
+        member.changeType(MemberType.DRIVER);// member type DRIVER 로 변경
+        driverRepository.save(driver);
+    }
+}

--- a/src/main/java/com/mate/carpool/domain/image/service/ImageService.java
+++ b/src/main/java/com/mate/carpool/domain/image/service/ImageService.java
@@ -1,0 +1,56 @@
+package com.mate.carpool.domain.image.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.mate.carpool.shared.exception.CustomHttpException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+    private final AmazonS3Client client;
+
+    @Value("${aws.bucket.name}")
+    private String bucketName;
+    @Value("${car.default.url}")
+    private String DEFAULT_CAR_IMAGE_URL;
+
+    /**
+     * 이미지 업로드를 위한 메소드
+     */
+    public String upload(MultipartFile file) throws IOException {
+        if(file == null || file.isEmpty()) return DEFAULT_CAR_IMAGE_URL;
+        if (!isImage(file.getOriginalFilename())) {
+            throw new CustomHttpException(HttpStatus.BAD_REQUEST, "확장자가 png, jpg, jpeg 경우만 이미지를 업로드 하실 수 있습니다.");
+        }
+
+        String newImageName = UUID.randomUUID().toString() + "-" + file.getOriginalFilename();
+        ObjectMetadata metadata = new ObjectMetadata();
+
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
+
+        // image aws s3 upload
+        client.putObject(
+                new PutObjectRequest(bucketName, newImageName, file.getInputStream(), metadata)
+                        .withCannedAcl(CannedAccessControlList.PublicRead)
+        );
+
+        return client.getUrl(bucketName, newImageName).toString();
+    }
+
+    private boolean isImage(String fileName) {
+        if (fileName == null) return false;
+        fileName = fileName.toLowerCase();
+        return fileName.endsWith(".png") || fileName.endsWith(".jpg") || fileName.endsWith(".jpeg");
+    }
+}

--- a/src/main/java/com/mate/carpool/domain/member/aggregate/Member.java
+++ b/src/main/java/com/mate/carpool/domain/member/aggregate/Member.java
@@ -37,4 +37,9 @@ public class Member extends BaseTimeEntity {
         this.profileImageUrl = profileImageUrl;
         this.type = type;
     }
+
+    // domain logic
+    public void changeType(MemberType type){
+        this.type = type;
+    }
 }

--- a/src/main/java/com/mate/carpool/web/auth/dto/MemberCreateRequestDTO.java
+++ b/src/main/java/com/mate/carpool/web/auth/dto/MemberCreateRequestDTO.java
@@ -12,7 +12,7 @@ public class MemberCreateRequestDTO {
     @Email(message = "이메일 형식이 잘못되었습니다.")
     private String email;
 
-    @NotNull(message = "비밃번호가 공백이면 안됩니다.")
+    @NotNull(message = "비밀번호가 공백이면 안됩니다.")
     @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,}$",message = "최소 8 자, 대문자 하나 이상, 소문자 하나 및 숫자 하나를 입력하셔야합니다.")
     private String password;
 

--- a/src/main/java/com/mate/carpool/web/driver/DriverController.java
+++ b/src/main/java/com/mate/carpool/web/driver/DriverController.java
@@ -1,0 +1,45 @@
+package com.mate.carpool.web.driver;
+
+
+import com.mate.carpool.domain.driver.dto.DriverCreateDTO;
+import com.mate.carpool.domain.driver.service.CarpoolDriverService;
+import com.mate.carpool.domain.image.service.ImageService;
+import com.mate.carpool.shared.dto.CommonResponse;
+import com.mate.carpool.shared.exception.CustomHttpException;
+import com.mate.carpool.web.driver.dto.DriverCreateRequestDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.security.Principal;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/driver")
+public class DriverController {
+
+    private final CarpoolDriverService driverService;
+    private final ImageService imageService;
+
+    @PostMapping("")
+    public ResponseEntity<CommonResponse> create(
+            Principal principal,
+            @Validated @RequestPart(value = "dto") DriverCreateRequestDTO dto,
+            @RequestPart(value = "image") MultipartFile image
+    ) {
+        String email = principal.getName();
+        try {
+            driverService.create(email, image, new DriverCreateDTO(dto.getCarNumber(), dto.getPhoneNumber()));
+        } catch (IOException e) {
+            throw new CustomHttpException(HttpStatus.INTERNAL_SERVER_ERROR, "image upload 도중에 예상치 못한 문제가 발생하였습니다.");
+        }
+        return ResponseEntity.ok(new CommonResponse(HttpStatus.OK, "성공적으로 드라이버 등록을 하였습니다."));
+    }
+}

--- a/src/main/java/com/mate/carpool/web/driver/dto/DriverCreateRequestDTO.java
+++ b/src/main/java/com/mate/carpool/web/driver/dto/DriverCreateRequestDTO.java
@@ -1,0 +1,16 @@
+package com.mate.carpool.web.driver.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+@Getter
+public class DriverCreateRequestDTO {
+    @NotNull
+    private String carNumber;
+
+    @NotNull
+    @Pattern(regexp = "[0-9]{11}", message = "숫자만 11개 입력하셔야 합니다.")
+    private String phoneNumber;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,4 +2,4 @@ server:
   port: 8880
 spring:
   profiles:
-    active: test
+    active: dev


### PR DESCRIPTION
#### 구현 사항
- aws s3를 이용한 사용자 이미지 업로드 구현 완료
    - 파일 이름 형식 : uuid + '-' + original file name
- 드라이버 정보 생성 및 사용자 유형 업데이트(PASSENGER -> DRIVER)

#### 논의 해야할 점
- 현재 사용자 이미지를 제 개인 S3의 IAM로 구현하였는데 mate 전용 개발 AWS 계정의 필요성이 느껴집니다. 
- 차량 번호에 대한 validate를 어떻게 설정할 것인가