### PR TITLE
fix : 예외 상황 발생시 body의 status가 http header status에 적용되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/mate/carpool/shared/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/mate/carpool/shared/exception/handler/GlobalExceptionHandler.java
@@ -2,8 +2,8 @@ package com.mate.carpool.shared.exception.handler;
 
 import com.mate.carpool.shared.dto.ErrorResponse;
 import com.mate.carpool.shared.exception.CustomHttpException;
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,13 +12,17 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomHttpException.class)
-    public ErrorResponse customHttpException(CustomHttpException exception) {
-        return new ErrorResponse(exception.getStatus(), exception.getMessage());
+    public ResponseEntity<ErrorResponse> customHttpException(CustomHttpException exception) {
+        return ResponseEntity
+                .status(exception.getStatus())
+                .body(new ErrorResponse(exception.getStatus(), exception.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ErrorResponse methodArgumentNotValidException(MethodArgumentNotValidException exception) {
-        return new ErrorResponse(HttpStatus.BAD_REQUEST,exception.getMessage());
+    public ResponseEntity<ErrorResponse> methodArgumentNotValidException(MethodArgumentNotValidException exception) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(HttpStatus.BAD_REQUEST, exception.getMessage()));
     }
 }
 


### PR DESCRIPTION
CustomHttpException 의 HttpStatus를 header에 적용해서 문제를 해결하였습니다.
초기 세팅 때 해당 문제를 찾았어야하는데 기능 추가 도중에 발견하여서 지금 수정합니다.